### PR TITLE
Fixed misc about diaplayed_advertiser (before translation)

### DIFF
--- a/Programming_Guide_English.md
+++ b/Programming_Guide_English.md
@@ -209,7 +209,7 @@ These options below are capable to be assigned.
 |---|---|---|---|
 | title_length | Assign the maximum length of title | `5` | `This is title` -> `This...`|
 | description_length | Assign the maximum length of description | `10` | `This is description` -> `This is des...`|  
-| displayed_advertiser_length | Assign the maximum length of advertiser's name | `5` | `Provided by test advertiser` -> `Test ad… |
+| displayed_advertiser_length | Assign the maximum length of advertiser's name（10 以下は無効です） | `11` | `株式会社テスト広告主提供` -> `株式会社テスト広告主…`
 
 ### Editing by callback functions
 

--- a/Programming_Guide_English.md
+++ b/Programming_Guide_English.md
@@ -527,3 +527,4 @@ It creates `MTBADVS` argument just beneath `window` object. Use `MTBADVS` argume
 ## What is meaning of `Instream` in codes?
 
 It has same role as `In-Feed` in the guide.
+

--- a/Programming_Guide_English.md
+++ b/Programming_Guide_English.md
@@ -209,7 +209,7 @@ These options below are capable to be assigned.
 |---|---|---|---|
 | title_length | Assign the maximum length of title | `5` | `This is title` -> `This...`|
 | description_length | Assign the maximum length of description | `10` | `This is description` -> `This is des...`|  
-| displayed_advertiser_length | Assign the maximum length of advertiser's name（The number less than 10 is disabled） | `11` | `Provided by test advertiser` -> `Test advertiser inc. …`
+| displayed_advertiser_length | Assign the maximum length of advertiser's name（The number less than 10 is disabled） | `11` | `Provided by test advertiser` -> `Provided b…`
 
 ### Editing by callback functions
 

--- a/Programming_Guide_English.md
+++ b/Programming_Guide_English.md
@@ -209,7 +209,7 @@ These options below are capable to be assigned.
 |---|---|---|---|
 | title_length | Assign the maximum length of title | `5` | `This is title` -> `This...`|
 | description_length | Assign the maximum length of description | `10` | `This is description` -> `This is des...`|  
-| displayed_advertiser_length | Assign the maximum length of advertiser's name（10 以下は無効です） | `11` | `株式会社テスト広告主提供` -> `株式会社テスト広告主…`
+| displayed_advertiser_length | Assign the maximum length of advertiser's name（The number less than 10 is disabled） | `11` | `Provided by test advertiser` -> `Test advertiser inc. …`
 
 ### Editing by callback functions
 


### PR DESCRIPTION
広告主名表記の制限に関する仕様修正について、マニュアルの英訳をお願いします。

- こちらのページから編集ください
  - https://github.com/mtburn/MTBurn-JavaScript-SDK-Install-Guide/blob/fixed-misc-displayed-advertiser/Programming_Guide_English.md
- 日本語の差分はこちらです
  - https://github.com/mtburn/MTBurn-JavaScript-SDK-Install-Guide/commit/bc8146e99b836399f614550d69e32c70d23cec35
